### PR TITLE
Implement a resource manager to take care of garbages objects

### DIFF
--- a/scim2_tester/resource.py
+++ b/scim2_tester/resource.py
@@ -1,7 +1,5 @@
-from scim2_models import Mutability
 from scim2_models import ResourceType
 
-from scim2_tester.filling import fill_with_random_values
 from scim2_tester.resource_delete import check_object_deletion
 from scim2_tester.resource_get import check_object_query
 from scim2_tester.resource_get import check_object_query_without_id
@@ -17,6 +15,12 @@ def check_resource_type(
     conf: CheckConfig,
     resource_type: ResourceType,
 ) -> list[CheckResult]:
+    """Orchestrate CRUD tests for a resource type.
+
+    :param conf: The check configuration containing the SCIM client
+    :param resource_type: The ResourceType object to test
+    :returns: A list of check results for all tested operations
+    """
     model = model_from_resource_type(conf, resource_type)
     if not model:
         return [
@@ -28,59 +32,12 @@ def check_resource_type(
         ]
 
     results = []
-    garbages = []
-    created_obj = None
 
-    # Always try to create an object - the decorator will decide if it should be skipped
-    field_names = [
-        field_name
-        for field_name in model.model_fields.keys()
-        if model.get_field_annotation(field_name, Mutability)
-        in (Mutability.read_write, Mutability.write_only, Mutability.immutable)
-    ]
-    obj, obj_garbages = fill_with_random_values(conf, model(), field_names)
-    garbages += obj_garbages
-
-    create_result = check_object_creation(conf, obj)
-
-    # Only add to results if creation was explicitly requested (not skipped)
-    if create_result.status != Status.SKIPPED:
-        results.append(create_result)
-
-    # If creation succeeded (either explicitly or as dependency), we have an object
-    if create_result.status == Status.SUCCESS:
-        created_obj = create_result.data
-
-        # Try read operations - decorator will skip if not needed
-        read_result = check_object_query(conf, created_obj)
-        if read_result.status != Status.SKIPPED:
-            results.append(read_result)
-
-        read_without_id_result = check_object_query_without_id(conf, created_obj)
-        if read_without_id_result.status != Status.SKIPPED:
-            results.append(read_without_id_result)
-
-        # Try update operations - decorator will skip if not needed
-        field_names = [
-            field_name
-            for field_name in model.model_fields.keys()
-            if model.get_field_annotation(field_name, Mutability)
-            in (Mutability.read_write, Mutability.write_only)
-        ]
-        _, obj_garbages = fill_with_random_values(conf, created_obj, field_names)
-        garbages += obj_garbages
-
-        update_result = check_object_replacement(conf, created_obj)
-        if update_result.status != Status.SKIPPED:
-            results.append(update_result)
-
-        # Try delete operations - decorator will skip if not needed
-        delete_result = check_object_deletion(conf, created_obj)
-        if delete_result.status != Status.SKIPPED:
-            results.append(delete_result)
-
-    # Cleanup remaining garbage
-    for garbage in reversed(garbages):
-        conf.client.delete(garbage)
+    # Each test is now completely independent and handles its own cleanup
+    results.append(check_object_creation(conf, model))
+    results.append(check_object_query(conf, model))
+    results.append(check_object_query_without_id(conf, model))
+    results.append(check_object_replacement(conf, model))
+    results.append(check_object_deletion(conf, model))
 
     return results

--- a/scim2_tester/resource_delete.py
+++ b/scim2_tester/resource_delete.py
@@ -2,18 +2,48 @@ from scim2_models import Resource
 
 from scim2_tester.utils import CheckConfig
 from scim2_tester.utils import CheckResult
+from scim2_tester.utils import ResourceManager
 from scim2_tester.utils import Status
 from scim2_tester.utils import checker
 
 
 @checker("crud:delete")
-def check_object_deletion(conf: CheckConfig, obj: Resource) -> CheckResult:
-    """Perform an object deletion."""
+def check_object_deletion(
+    conf: CheckConfig, model: type[Resource], resources: ResourceManager
+) -> CheckResult:
+    """Test object deletion with automatic cleanup.
+
+    Creates a test object specifically for deletion testing, performs the
+    delete operation, and verifies the object no longer exists.
+
+    :param conf: The check configuration containing the SCIM client
+    :param model: The Resource model class to test
+    :param resources: Resource manager for automatic cleanup
+    :returns: The result of the check operation
+    """
+    test_obj = resources.create_and_register(model)
+
+    # Remove from resource manager since we're testing deletion explicitly
+    if test_obj in resources.resources:
+        resources.resources.remove(test_obj)
+
     conf.client.delete(
-        obj.__class__, obj.id, expected_status_codes=conf.expected_status_codes or [204]
+        model, test_obj.id, expected_status_codes=conf.expected_status_codes or [204]
     )
+
+    try:
+        conf.client.query(model, test_obj.id)
+        return CheckResult(
+            conf,
+            status=Status.ERROR,
+            reason=f"{model.__name__} object with id {test_obj.id} still exists after deletion",
+        )
+    except Exception:
+        # Expected - object should not exist after deletion
+        pass
+
     return CheckResult(
         conf,
         status=Status.SUCCESS,
-        reason=f"Successful deletion of a {obj.__class__.__name__} object with id {obj.id}",
+        reason=f"Successfully deleted {model.__name__} object with id {test_obj.id}",
     )

--- a/scim2_tester/resource_post.py
+++ b/scim2_tester/resource_post.py
@@ -2,26 +2,30 @@ from scim2_models import Resource
 
 from scim2_tester.utils import CheckConfig
 from scim2_tester.utils import CheckResult
+from scim2_tester.utils import ResourceManager
 from scim2_tester.utils import Status
 from scim2_tester.utils import checker
 
 
 @checker("crud:create")
-def check_object_creation(conf: CheckConfig, obj: Resource) -> CheckResult:
-    """Perform an object creation.
+def check_object_creation(
+    conf: CheckConfig, model: type[Resource], resources: ResourceManager
+) -> CheckResult:
+    """Test object creation with automatic cleanup.
 
-    Todo:
-      - check if the fields of the result object are the same than the
-      fields of the request object
+    Creates a test object of the specified model type, validates the creation
+    operation.
 
+    :param conf: The check configuration containing the SCIM client
+    :param model: The Resource model class to test
+    :param resources: Resource manager for automatic cleanup
+    :returns: The result of the check operation
     """
-    response = conf.client.create(
-        obj, expected_status_codes=conf.expected_status_codes or [201]
-    )
+    created_obj = resources.create_and_register(model)
 
     return CheckResult(
         conf,
         status=Status.SUCCESS,
-        reason=f"Successful creation of a {obj.__class__.__name__} object with id {response.id}",
-        data=response,
+        reason=f"Successfully created {model.__name__} object with id {created_obj.id}",
+        data=created_obj,
     )

--- a/scim2_tester/resource_put.py
+++ b/scim2_tester/resource_put.py
@@ -1,26 +1,51 @@
+from scim2_models import Mutability
 from scim2_models import Resource
 
+from scim2_tester.filling import fill_with_random_values
 from scim2_tester.utils import CheckConfig
 from scim2_tester.utils import CheckResult
+from scim2_tester.utils import ResourceManager
 from scim2_tester.utils import Status
 from scim2_tester.utils import checker
 
 
 @checker("crud:update")
-def check_object_replacement(conf: CheckConfig, obj: Resource) -> CheckResult:
-    """Perform an object replacement.
+def check_object_replacement(
+    conf: CheckConfig, model: type[Resource], resources: ResourceManager
+) -> CheckResult:
+    """Test object replacement (PUT) with automatic cleanup.
 
-    Todo:
-      - check if the fields of the result object are the same than the
-      fields of the request object
+    Creates a test object, modifies its mutable fields, performs a replacement
+    operation to validate the update functionality.
 
+    :param conf: The check configuration containing the SCIM client
+    :param model: The Resource model class to test
+    :param resources: Resource manager for automatic cleanup
+    :returns: The result of the check operation
     """
+    test_obj = resources.create_and_register(model)
+
+    mutable_fields = [
+        field_name
+        for field_name in model.model_fields.keys()
+        if model.get_field_annotation(field_name, Mutability)
+        in (Mutability.read_write, Mutability.write_only)
+    ]
+
+    modified_obj = fill_with_random_values(conf, test_obj, resources, mutable_fields)
+
+    if modified_obj is None:
+        raise ValueError(
+            f"Could not modify {model.__name__} object with mutable fields"
+        )
+
     response = conf.client.replace(
-        obj, expected_status_codes=conf.expected_status_codes or [200]
+        modified_obj, expected_status_codes=conf.expected_status_codes or [200]
     )
+
     return CheckResult(
         conf,
         status=Status.SUCCESS,
-        reason=f"Successful replacement of a {obj.__class__.__name__} object with id {response.id}",
+        reason=f"Successfully replaced {model.__name__} object with id {test_obj.id}",
         data=response,
     )

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -5,7 +5,9 @@ from scim2_models import ComplexAttribute
 from scim2_models import Reference
 from scim2_models import Resource
 
-from scim2_tester.resource import fill_with_random_values
+from scim2_tester.filling import fill_with_random_values
+from scim2_tester.utils import CheckConfig
+from scim2_tester.utils import ResourceManager
 
 
 class Complex(ComplexAttribute):
@@ -47,8 +49,22 @@ class CustomModel(Resource):
 
 def test_random_values():
     """Check that 'fill_with_random_values' produce valid objects."""
+
+    # Create a mock config and resource manager for testing
+    class MockClient:
+        def create(self, obj):
+            return obj
+
+    conf = CheckConfig(MockClient())
+    resource_manager = ResourceManager(conf)
+
     obj = CustomModel()
-    fill_with_random_values(None, obj)
+    obj = fill_with_random_values(conf, obj, resource_manager)
+
+    assert obj is not None, (
+        "fill_with_random_values should not return None for test object"
+    )
+
     for field_name in obj.__class__.model_fields:
         if field_name == "meta":
             continue


### PR DESCRIPTION
This should clean up the code a bit.
Also, clearly separate the CRUD checks.