### PR TITLE
Correctly set values for Reference objects in parent object

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Fixed
 ^^^^^
 - Sort results in get_all_available_tags, so it can be used with pytest-xdist.
+- `generate_random_value` generate coherent `ref` and `value` values for complex attributes. :pr:`30` :pr:`37`
 
 [0.2.0] - 2025-08-12
 --------------------

--- a/scim2_tester/filling.py
+++ b/scim2_tester/filling.py
@@ -11,6 +11,7 @@ from typing import get_origin
 from scim2_models import ComplexAttribute
 from scim2_models import Extension
 from scim2_models import ExternalReference
+from scim2_models import MultiValuedComplexAttribute
 from scim2_models import Mutability
 from scim2_models import Reference
 from scim2_models import Resource
@@ -123,6 +124,9 @@ def generate_random_value(
     elif isclass(field_type) and issubclass(field_type, Enum):
         value = random.choice(list(field_type))
 
+    elif isclass(field_type) and issubclass(field_type, MultiValuedComplexAttribute):
+        value = fill_mvca_with_random_values(context, field_type())  # type: ignore[arg-type]
+
     elif isclass(field_type) and issubclass(field_type, ComplexAttribute):
         value = fill_with_random_values(context, field_type())  # type: ignore[arg-type]
 
@@ -171,4 +175,25 @@ def fill_with_random_values(
         value = generate_random_value(context, urn=urn, model=type(obj))
         set_value_by_urn(obj, urn, value)
 
+    return obj
+
+
+def fill_mvca_with_random_values(
+    context: "CheckContext",
+    obj: MultiValuedComplexAttribute,
+) -> Resource[Any] | None:
+    """Fill a MultiValuedComplexAttribute with random values.
+
+    For SCIM reference fields, correctly sets the value field to match
+    the ID extracted from the reference URL.
+    """
+    fill_with_random_values(context, obj)
+    ref_type = type(obj).get_field_root_type("ref")
+    if (
+        get_origin(ref_type) is Reference
+        and get_args(ref_type)
+        and get_args(ref_type)[0] not in (URIReference, ExternalReference, Any)
+        and (ref := getattr(obj, "ref", None))
+    ):
+        obj.value = ref.rsplit("/", 1)[-1]
     return obj

--- a/tests/test_filling.py
+++ b/tests/test_filling.py
@@ -33,9 +33,23 @@ def test_model_resolution_from_reference_type(testing_context):
     assert result != Group
 
 
-def test_generate_random_value_for_reference(testing_context):
+def test_generate_random_value_for_reference(testing_context, httpserver):
     """Validates random value generation for reference fields."""
     group = Group()
+
+    # Mock HTTP response for user creation
+    user_data = {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id": "test-user-id",
+        "userName": "test-user",
+        "meta": {
+            "resourceType": "User",
+            "location": f"http://localhost:{httpserver.port}/Users/test-user-id",
+        },
+    }
+    httpserver.expect_request("/Users", method="POST").respond_with_json(
+        user_data, status=201
+    )
 
     result = fill_with_random_values(testing_context, group)
 


### PR DESCRIPTION
Values of `User` and `Group` objects are wrong, The id in the `value` files does not match the id of the actually created object. This leads to problems when the scim server validates if a member really exists.

The changes in this MR first creates all ref objects and than fills the values correctly with the correct type and id.

This is a follow up of #30 